### PR TITLE
add -y flag to skip confirm (#17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ To download a specific older version, use
 
 Where `x.y.z` is the desired version.
 
+
+If you wish to run the install script without interactive prompts, please clone this repository and run the following:
+
+    bash jill.sh -y
+
 ## LICENSE
 
 This script is licensed under the GNU GPLv3 (see

--- a/jill.sh
+++ b/jill.sh
@@ -17,6 +17,19 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+# Skip confirm if -y is used.
+SKIP_CONFIRM=0
+while getopts ":y" opt; do
+  case $opt in
+    y)
+      SKIP_CONFIRM=1
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      exit 1;
+      ;;
+  esac
+done
 
 # For Linux, this script installs Julia into $JULIA_DOWNLOAD and make a
 # link to $JULIA_INSTALL
@@ -41,18 +54,18 @@ function badfolder() {
   echo "The folder '$JULIA_INSTALL' is not on your PATH, you can"
   echo "- 1) Add it to your path; or"
   echo "- 2) Run 'JULIA_INSTALL=otherfolder ./jill.sh'"
-
-  read -p "Do you want to add '$JULIA_INSTALL' into your PATH? (Y/N) " -n 1 -r
-  echo
-  if [[ ! $REPLY =~ ^[Yy] ]]; then
-    echo "Aborted"
-    exit 1
-  else
-    echo 'export PATH="'"$JULIA_INSTALL"':$PATH"' | tee -a ~/.bashrc
-    echo ""
-    echo "run 'source ~/.bashrc' or restart your bash to reload the PATH"
-    echo ""
+  if [[ "$SKIP_CONFIRM" == "0" ]]; then
+    read -p "Do you want to add '$JULIA_INSTALL' into your PATH? (Y/N) " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy] ]]; then
+      echo "Aborted"
+      exit 1
+    fi
   fi
+  echo 'export PATH="'"$JULIA_INSTALL"':$PATH"' | tee -a ~/.bashrc
+  echo ""
+  echo "run 'source ~/.bashrc' or restart your bash to reload the PATH"
+  echo ""
 }
 
 function hi() {
@@ -175,7 +188,9 @@ function install_julia_mac() {
 
 # Main
 hi
-confirm
+if [[ "$SKIP_CONFIRM" == "0" ]]; then
+    confirm
+fi
 unameOut="$(uname -s)"
 case "${unameOut}" in
     Linux*) install_julia_linux ;;

--- a/travis-test.sh
+++ b/travis-test.sh
@@ -25,3 +25,6 @@ julia-$VERSION -v
 
 msg "Testing if the version is correct"
 [[ $(julia-$VERSION -v) == "julia version $VERSION" ]]
+
+msg "Installing latest Julia without interactive prompt"
+bash jill.sh -y


### PR DESCRIPTION
* add -y flag to skip confirm

Bash doesn't allow you to use long options, so I implemented `-y` which will allow a user to skip the confirmation for install and error if they add any other option.

* Fix indentation